### PR TITLE
Adds 'clamp' (vs Numpy's 'clip')

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: python -m pip install --upgrade pip setuptools wheel openstudio oslg numpy
+        run: python -m pip install --upgrade pip setuptools wheel openstudio oslg
       - name: Run unit tests
         run: python -m unittest
 
@@ -37,6 +37,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: python -m pip install --upgrade pip setuptools wheel openstudio oslg numpty
+        run: python -m pip install --upgrade pip setuptools wheel openstudio oslg
       - name: Run unit tests
         run: python -m unittest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osut"
-version = "0.6.0a2"
+version = "0.6.0a3"
 description = "OpenStudio SDK utilities for Python"
 readme = "README.md"
 requires-python = ">=3.2"


### PR DESCRIPTION
_OSut_ operates heavily off of OpenStudio's SWIG Python bindings (i.e. `import openstudio`). It also relies on [OSlg](https://pypi.org/project/oslg/) as an external logger. In addition, _OSut_ relies on a handful of built-in (_internal_) Python packages/modules:

- **re**
- **math**
- **collections**
- **dataclasses**

**Numpy** is the only _external_ Python package/module, used solely to `clip` numbers (within a min/max range). This PR adds an in-house function, `clamp`: a proxy to _Numpy_'s `clip` and/or Ruby's `clamp`. 

There's probably not much of an overhead in importing _Numpy_, yet seems overkill for a single function.